### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 class TokenGenerator {
   constructor(bitSize, baseEncoding) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 const TokenGenerator = require('../');
 
 const should = require('should');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 describe('TokenGenerator', () => {
 
@@ -129,7 +129,7 @@ describe('TokenGenerator', () => {
     });
 
     it('should produce a token of the correct length even if the uuid function returns a small token value', () => {
-      // Mock node-uuid.v4
+      // Mock uuid.v4
       uuid.v4 = function(options, buffer, offset) {
         offset = offset || 0;
         for (var i = 0; i < 16; i++) {
@@ -142,7 +142,7 @@ describe('TokenGenerator', () => {
     });
 
     it('should work if the generated UUID has leading zeros', () => {
-      // Mock node-uuid.v4
+      // Mock uuid.v4
       uuid.v4 = function(options, buffer, offset) {
         offset = offset || 0;
         buffer[offset] = 0;


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.